### PR TITLE
MVP for connecting to spot fleet instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ Possible options are below. If left blank, they will be ignored and defaults use
 
 Argument | Description
 -------- | -----------
-cluster_name | The name of the cluster (not the ARN). eg 'my-super-cluster'. Required
+cluster_name | The name of the cluster (not the ARN). eg 'my-super-cluster'. Required (unless using spot_request_id)
+spot_request_id | The spot request ID you are connecting to. eg 'sfr-abcdef'. Required (unless using cluster_name)
 region | The AWS region you would like to use. Defaults to `us-east-1`
 bastion | if you have a bastion to proxy to your ecs cluster via ssh, put the name of it here as defined in your `~/.ssh/config` file.
 rsa_key_location | The RSA key needed to connect to an ecs agent eg `~/.ssh/id_rsa`.
@@ -194,6 +195,8 @@ sudo | true or false - will sudo the `docker` command on the target machine. Usu
 aws_vault_profile | If you use the `aws-vault` tool to manage your AWS credentials, you can specify a profile here that will be automatically used to connect to this cluster.
 profile | Another profile to inherit settings from. Settings from lower profiles can be overridden in higher ones.
 
+## Spot Fleets
+If you wish to see what instances are running within a spot fleet, KnuckleCluster can do that too!.  In your config, use `spot_request_id` instead of `cluster_name`.  Note that the `containers` command will not work when invoking.
 
 ## Maintainer
 [Envato](https://github.com/envato)

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -185,18 +185,19 @@ module KnuckleCluster
     end
 
     def agent_registry
-      @agent_registry ||= ()
-      if @cluster_name
-        EcsAgentRegistry.new(
-          aws_client_config: aws_client_config,
-          cluster_name:      cluster_name,
-        )
-      elsif @spot_request_id
-        SpotRequestInstanceRegistry.new(
-          aws_client_config: aws_client_config,
-          spot_request_id:   spot_request_id,
-        )
-      end
+      @agent_registry ||= (
+        if @cluster_name
+          EcsAgentRegistry.new(
+            aws_client_config: aws_client_config,
+            cluster_name:      cluster_name,
+          )
+        elsif @spot_request_id
+          SpotRequestInstanceRegistry.new(
+            aws_client_config: aws_client_config,
+            spot_request_id:   spot_request_id,
+          )
+        end
+      )
     end
 
     def_delegators :agent_registry, :agents, :tasks, :containers, :output_agents

--- a/lib/knuckle_cluster/agent.rb
+++ b/lib/knuckle_cluster/agent.rb
@@ -6,8 +6,8 @@ module KnuckleCluster
       public_ip:,
       private_ip:,
       availability_zone:,
-      container_instance_arn:,
-      task_registry:
+      container_instance_arn: nil,
+      task_registry: nil
     )
       @index = index
       @instance_id = instance_id

--- a/lib/knuckle_cluster/ecs_agent_registry.rb
+++ b/lib/knuckle_cluster/ecs_agent_registry.rb
@@ -4,7 +4,7 @@ require 'knuckle_cluster/task_registry'
 require 'forwardable'
 
 module KnuckleCluster
-  class AgentRegistry
+  class EcsAgentRegistry
     extend Forwardable
 
     def initialize(aws_client_config:, cluster_name:)
@@ -18,6 +18,17 @@ module KnuckleCluster
 
     def find_by(container_instance_arn:)
       agents_by_container_instance_arn[container_instance_arn]&.first
+    end
+
+    def output_agents
+      tp agents,
+        :index,
+        :instance_id,
+        # :public_ip,
+        # :private_ip,
+        # :availability_zone,
+        { task: { display_method: 'tasks.name', width: 999 } },
+        { container: { display_method: 'tasks.containers.name', width: 999 } }
     end
 
     def_delegators :task_registry, :tasks, :containers

--- a/lib/knuckle_cluster/spot_request_instance_registry.rb
+++ b/lib/knuckle_cluster/spot_request_instance_registry.rb
@@ -1,0 +1,53 @@
+require 'knuckle_cluster/agent'
+
+require 'forwardable'
+
+module KnuckleCluster
+  class SpotRequestInstanceRegistry
+    extend Forwardable
+
+    def initialize(aws_client_config:, spot_request_id:)
+      @aws_client_config = aws_client_config
+      @spot_request_id   = spot_request_id
+    end
+
+    def agents
+      @agents ||= load_agents
+    end
+
+    def output_agents
+      tp agents,
+        :index,
+        :instance_id,
+        # :public_ip,
+        :private_ip,
+        :availability_zone
+    end
+
+    private
+
+    attr_reader :aws_client_config, :spot_request_id
+
+    def load_agents
+      spot_fleet_instances = ec2_client.describe_spot_fleet_instances(spot_fleet_request_id: spot_request_id)
+      instance_ids = spot_fleet_instances.active_instances.map(&:instance_id)
+
+      instance_reservations = ec2_client.describe_instances(instance_ids: instance_ids).reservations
+
+      instance_reservations.map(&:instances).flatten.map.with_index do |instance, index|
+        Agent.new(
+          index:                  index + 1,
+          instance_id:            instance[:instance_id],
+          public_ip:              instance[:public_ip_address],
+          private_ip:             instance[:private_ip_address],
+          availability_zone:      instance.dig(:placement, :availability_zone),
+        )
+      end
+    end
+
+    def ec2_client
+      @ec2_client ||= Aws::EC2::Client.new(aws_client_config)
+    end
+
+  end
+end

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Start of a discussion I guess on how to include things like spot fleets and ASG's into this utility.
Is it feature creep? Probably.  Is it useful? For shizzle.
A lot of the code was reusable (the ssh connection string stuff is especially useful in this instance).
I needed to
* Create a new class to load the agents from the spot fleet
* Move the table render into the agent registry classes

I think this can also benefit from a little rework and refactoring - Since the system wasn't designed with this in mind, this implementation could do with a bit of thought to make the whole thing a little more extensible in future (when I add ASG's)