### PR TITLE
Tidy up error message

### DIFF
--- a/lib/knuckle_cluster/asg_instance_registry.rb
+++ b/lib/knuckle_cluster/asg_instance_registry.rb
@@ -31,6 +31,11 @@ module KnuckleCluster
     def load_agents
       auto_scaling_instances = autoscaling_client.describe_auto_scaling_groups(auto_scaling_group_names: [@asg_name]).to_h
 
+      if auto_scaling_instances[:auto_scaling_groups].empty?
+        puts "Could not find auto scaling group '#{asg_name}' in region #{aws_client_config[:region]}."
+        exit(0)
+      end
+
       instance_ids = auto_scaling_instances[:auto_scaling_groups][0][:instances].map{|instance| instance[:instance_id]}
 
       instance_reservations = ec2_client.describe_instances(instance_ids: instance_ids).reservations

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Previously, when trying to connect to an ASG it couldn't find, it would give `undefined method '[]' for nil:NilClass (NoMethodError)` which wasnt very nice.  This makes it nicer!

This is only an issue for ASG's and the spot and ecs registrys throw actual aws errors.

Future work will define 'real' error classes and catch them all higher up.