### PR TITLE
Add functionality to SCP files to containers or agents

### DIFF
--- a/bin/knuckle_cluster
+++ b/bin/knuckle_cluster
@@ -12,6 +12,7 @@ if ARGV.count < 2
     knuckle_cluster CLUSTER_PROFILE CONTAINER_NAME [OPTIONAL COMMANDS] - connect to a container and start a shell or run a command
     knuckle_cluster CLUSTER_PROFILE SHORTCUT_NAME - run a shortcut defined in your knuckle_cluster configuration
     knuckle_cluster CLUSTER_PROFILE tunnel TUNNEL_NAME - open a tunnel defined in your knuckle_cluster configuration
+    knuckle_cluster CLUSTER_PROFILE scp [agent|container] source_file destination - copies a file from your local machine to a destaination container or agent
   USAGE
   exit
 end
@@ -35,6 +36,12 @@ elsif ARGV[1] == 'logs'
   kc.container_logs(name: ARGV[2])
 elsif ARGV[1] == 'tunnel'
   kc.open_tunnel(name: ARGV[2])
+elsif ARGV[1] == 'scp'
+  if ARGV[2] == 'agent'
+    kc.scp_to_agent(source: ARGV[3], destination: ARGV[4])
+  elsif ARGV[2] == 'container'
+    kc.scp_to_container(source: ARGV[3], destination: ARGV[4])
+  end
 else
   command = ARGV.drop(2)
   if command.any?

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '1.3.1'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
Added two new commands:

```
knuckle_cluster <cluster_name> scp agent ./poho.txt ~/poho.txt
```
copies poho.txt to location `~/poho.txt` on the destination agent.  This will ask which agent to use before performing the scp.

```
knuckle_cluster <cluster_name> scp container ./poho.txt /app/poho.txt
```
copies poho.txt to location `/app/poho.txt` on the destination container.  This will ask which container to use before performing the scp.
It SCP's the file to the agent first as a tempfile, then uses `docker cp` to copy into the running container.  Finally it deletes the temp file that was in use