### PR TITLE
Allow scp from things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.0.0] - 2018-03-27
+Refactor SCP implementation to use new syntax
+Allow SCP copy files FROM agents or containers

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ knuckle_cluster CLUSTER_PROFILE logs CONTAINER_NAME - tail the logs for a contai
 knuckle_cluster CLUSTER_PROFILE CONTAINER_NAME [OPTIONAL COMMANDS] - connect to a container and start a shell or run a command
 knuckle_cluster CLUSTER_PROFILE SHORTCUT_NAME - run a shortcut defined in your knuckle_cluster configuration
 knuckle_cluster CLUSTER_PROFILE tunnel TUNNEL_NAME - open a tunnel defined in your knuckle_cluster configuration
+knuckle_cluster CLUSTER_PROFILE scp source destination - copied a file via scp to or from a container or agent. Use container:<location> or agent:<location>
 ```
 
 ### Rakefile usage
@@ -202,6 +203,22 @@ If you wish to see what instances are running within a spot fleet, KnuckleCluste
 
 ## AutoScaling Groups
 If you wish to see what instances are running within an ASG, KnuckleCluster can do that too!.  In your config, use `asg_name` instead of `cluster_name`.  Note that the `containers` command will not work when invoking (use `agents` instead).
+
+## SCP
+You can use Knuckle Cluster to copy files in and out of agents or containers.  Note that this will only work where one of the source or destination is your local machine, copying between containers is not yet supported.  Use a syntax similar to existing `scp` syntax when specifying a source or destination, but use the keyword `container` or `agent` for the remote. When using one of these keywords, you will be prompted as to which agent/container you wish to use.
+```
+#Copy some_file.txt into a container at /app/some_file.txt
+knuckle_cluster super_platform scp ./some_file.txt container:/app/some_file.txt
+
+#Copy /app/some_file.txt from a remote container to ./some_file.txt on your local machine
+knuckle_cluster super_platform scp container:/app/some_file.txt ./some_file.txt
+
+#Copy some_file.txt into an agent at ~/some_file.txt
+knuckle_cluster super_platform scp ./some_file.txt agent:~/some_file.txt
+
+#Copy /app/some_file.txt from a remote container to ./some_file.txt on your local machine
+knuckle_cluster super_platform scp agent:~/some_file.txt ./some_file.txt
+```
 
 ## Maintainer
 [Envato](https://github.com/envato)

--- a/bin/knuckle_cluster
+++ b/bin/knuckle_cluster
@@ -12,7 +12,7 @@ if ARGV.count < 2
     knuckle_cluster CLUSTER_PROFILE CONTAINER_NAME [OPTIONAL COMMANDS] - connect to a container and start a shell or run a command
     knuckle_cluster CLUSTER_PROFILE SHORTCUT_NAME - run a shortcut defined in your knuckle_cluster configuration
     knuckle_cluster CLUSTER_PROFILE tunnel TUNNEL_NAME - open a tunnel defined in your knuckle_cluster configuration
-    knuckle_cluster CLUSTER_PROFILE scp [agent|container] source_file destination - copies a file from your local machine to a destaination container or agent
+    knuckle_cluster CLUSTER_PROFILE scp source destination - copied a file via scp to or from a container or agent. Use container:<location> or agent:<location>
   USAGE
   exit
 end
@@ -37,11 +37,7 @@ elsif ARGV[1] == 'logs'
 elsif ARGV[1] == 'tunnel'
   kc.open_tunnel(name: ARGV[2])
 elsif ARGV[1] == 'scp'
-  if ARGV[2] == 'agent'
-    kc.scp_to_agent(source: ARGV[3], destination: ARGV[4])
-  elsif ARGV[2] == 'container'
-    kc.scp_to_container(source: ARGV[3], destination: ARGV[4])
-  end
+  kc.initiate_scp(source: ARGV[2], destination: ARGV[3])
 else
   command = ARGV.drop(2)
   if command.any?

--- a/knuckle_cluster.gemspec
+++ b/knuckle_cluster.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~> 3.0"
+  spec.add_development_dependency "pry"
 
   spec.add_dependency 'aws-sdk-core',        '~> 3'
   spec.add_dependency 'aws-sdk-ec2',         '~> 1'

--- a/knuckle_cluster.gemspec
+++ b/knuckle_cluster.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~> 3.0"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry",     "~> 0.11"
 
   spec.add_dependency 'aws-sdk-core',        '~> 3'
   spec.add_dependency 'aws-sdk-ec2',         '~> 1'

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -1,6 +1,7 @@
 require 'knuckle_cluster/asg_instance_registry'
 require 'knuckle_cluster/ecs_agent_registry'
 require 'knuckle_cluster/spot_request_instance_registry'
+require "knuckle_cluster/scp"
 require "knuckle_cluster/version"
 require "knuckle_cluster/configuration"
 
@@ -15,6 +16,8 @@ require 'table_print'
 module KnuckleCluster
   class << self
     extend Forwardable
+
+    include Scp
 
     def new(
         cluster_name: nil,
@@ -66,84 +69,6 @@ module KnuckleCluster
 
       container = find_container(name: name)
       run_command_in_container(container: container, command: command)
-    end
-
-    def initiate_scp(source:, destination:)
-      if source.start_with?('agent') || destination.start_with?('agent')
-        agent = select_agent
-
-        if source.start_with?('agent')
-          source      = generate_agent_scp_string(source,      agent)
-        elsif destination.start_with?('agent')
-          destination = generate_agent_scp_string(destination, agent)
-        end
-
-        scp_with_agent(source: source, destination: destination, agent: agent)
-      elsif source.start_with?('container') || destination.start_with?('container')
-        container = select_container
-        agent     = container.task.agent
-        if source.start_with?('container')
-          #This is SCP FROM container
-          source = source.split(':').last
-          tmp_source_file = '~/tmp_kc.tmp'
-          container_id = get_container_id_command(container.name)
-
-          subcommand = "#{'sudo ' if sudo}docker cp \\`#{container_id}\\`:#{source} #{tmp_source_file}"
-          run_command_in_agent(agent: agent, command: subcommand)
-
-          scp_source = generate_agent_scp_string(tmp_source_file, agent)
-          scp_with_agent(source: scp_source, agent: agent, destination: destination)
-
-          subcommand = "#{'sudo ' if sudo} rm #{tmp_source_file}"
-          run_command_in_agent(agent: agent, command: subcommand)
-
-          puts "Done!"
-        elsif destination.start_with?('container')
-          #SCP TO container
-          destination = destination.split(':').last
-          tmp_destination_file = '~/tmp_kc.tmp'
-          tmp_destination = generate_agent_scp_string(tmp_destination_file, agent)
-          scp_with_agent(source: source, agent: agent, destination: tmp_destination)
-          container_id = get_container_id_command(container.name)
-          subcommand = "#{'sudo ' if sudo}docker cp #{tmp_destination_file} \\`#{container_id}\\`:#{destination} && rm #{tmp_destination_file}"
-          run_command_in_agent(agent: agent, command: subcommand)
-          puts "Done!"
-        end
-      end
-    end
-
-    def generate_agent_scp_string(input, agent)
-      split_input = input.split(':')
-      location    = split_input.last
-      target_ip = bastion ? agent.private_ip : agent.public_ip
-      return "#{ssh_username}@#{target_ip}:#{location}"
-    end
-
-    def scp_with_agent(source:, destination:, agent: nil)
-      command = generate_scp_connection_string(agent: agent)
-      command += " #{source}"
-      command += " #{destination}"
-      system(command)
-      puts "Done!"
-    end
-
-    def generate_scp_connection_string(agent:)
-      ip = bastion ? agent.private_ip : agent.public_ip
-      command = "scp"
-      command += " -i #{rsa_key_location}" if rsa_key_location
-      command += " -o ProxyCommand='ssh -qxT #{bastion} nc #{ip} 22'" if bastion
-      command
-    end
-
-    def scp_to_container(source:, destination:)
-      container = select_container
-      agent     = container.task.agent
-      tmp_destination_file = '~/tmp_kc.tmp'
-      scp_to_agent(source: source, agent: agent, destination: tmp_destination_file)
-      container_id = get_container_id_command(container.name)
-      subcommand = "#{'sudo ' if sudo}docker cp #{tmp_destination_file} \\`#{container_id}\\`:#{destination} && rm #{tmp_destination_file}"
-      run_command_in_agent(agent: agent, command: subcommand)
-      puts "Done!"
     end
 
     def container_logs(name:)

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -1,6 +1,7 @@
 require 'knuckle_cluster/asg_instance_registry'
 require 'knuckle_cluster/ecs_agent_registry'
 require 'knuckle_cluster/spot_request_instance_registry'
+require 'knuckle_cluster/scp'
 require "knuckle_cluster/version"
 require "knuckle_cluster/configuration"
 
@@ -68,14 +69,59 @@ module KnuckleCluster
       run_command_in_container(container: container, command: command)
     end
 
-    def scp_to_agent(source:, destination:, agent: nil)
-      agent ||= select_agent
+    def initiate_scp(source:, destination:)
+      if source.start_with?('agent') || destination.start_with?('agent')
+        agent = select_agent
+
+        if source.start_with?('agent')
+          source      = generate_agent_scp_string(source,      agent)
+        elsif destination.start_with?('agent')
+          destination = generate_agent_scp_string(destination, agent)
+        end
+
+        scp_with_agent(source: source, destination: destination, agent: agent)
+      elsif source.start_with?('container') || destination.start_with?('container')
+        container = select_container
+        agent     = container.task.agent
+        if source.start_with?('container')
+          #This is SCP FROM container
+          raise "SCP From container not yet implemented"
+        elsif destination.start_with?('container')
+          #SCP TO container
+          destination = destination.split(':').last
+          tmp_destination_file = '~/tmp_kc.tmp'
+          tmp_destination = generate_agent_scp_string(tmp_destination_file, agent)
+          scp_with_agent(source: source, agent: agent, destination: tmp_destination)
+          container_id = get_container_id_command(container.name)
+          subcommand = "#{'sudo ' if sudo}docker cp #{tmp_destination_file} \\`#{container_id}\\`:#{destination} && rm #{tmp_destination_file}"
+          puts subcommand
+          run_command_in_agent(agent: agent, command: subcommand)
+          puts "Done!"
+        end
+      end
+    end
+
+    def generate_agent_scp_string(input, agent)
+      split_input = input.split(':')
+      location    = split_input.last
       target_ip = bastion ? agent.private_ip : agent.public_ip
+      return "#{ssh_username}@#{target_ip}:#{location}"
+    end
+
+    def scp_with_agent(source:, destination:, agent: nil)
       command = generate_scp_connection_string(agent: agent)
       command += " #{source}"
-      command += " #{ssh_username}@#{target_ip}:#{destination}"
+      command += " #{destination}"
       system(command)
       puts "Done!"
+    end
+
+    def generate_scp_connection_string(agent:)
+      ip = bastion ? agent.private_ip : agent.public_ip
+      command = "scp"
+      command += " -i #{rsa_key_location}" if rsa_key_location
+      command += " -o ProxyCommand='ssh -qxT #{bastion} nc #{ip} 22'" if bastion
+      command
     end
 
     def scp_to_container(source:, destination:)
@@ -201,14 +247,6 @@ module KnuckleCluster
           credentials[var_name] = vars["AWS_#{var_name.upcase}"]&.first&.last
         end
       end
-    end
-
-    def generate_scp_connection_string(agent:)
-      ip = bastion ? agent.private_ip : agent.public_ip
-      command = "scp"
-      command += " -i #{rsa_key_location}" if rsa_key_location
-      command += " -o ProxyCommand='ssh -qxT #{bastion} nc #{ip} 22'" if bastion
-      command
     end
 
     def generate_connection_string(agent:, subcommand: nil, port_forward: nil)

--- a/lib/knuckle_cluster/scp.rb
+++ b/lib/knuckle_cluster/scp.rb
@@ -1,0 +1,81 @@
+module KnuckleCluster
+  module Scp
+    def initiate_scp(source:, destination:)
+      if source.start_with?('agent') || destination.start_with?('agent')
+        agent = select_agent
+
+        if source.start_with?('agent')
+          source      = generate_agent_scp_string(source,      agent)
+        elsif destination.start_with?('agent')
+          destination = generate_agent_scp_string(destination, agent)
+        end
+
+        scp_with_agent(source: source, destination: destination, agent: agent)
+      elsif source.start_with?('container') || destination.start_with?('container')
+        container = select_container
+        agent     = container.task.agent
+        if source.start_with?('container')
+          #This is SCP FROM container
+          source = source.split(':').last
+          tmp_source_file = '~/tmp_kc.tmp'
+          container_id = get_container_id_command(container.name)
+
+          subcommand = "#{'sudo ' if sudo}docker cp \\`#{container_id}\\`:#{source} #{tmp_source_file}"
+          run_command_in_agent(agent: agent, command: subcommand)
+
+          scp_source = generate_agent_scp_string(tmp_source_file, agent)
+          scp_with_agent(source: scp_source, agent: agent, destination: destination)
+
+          subcommand = "#{'sudo ' if sudo} rm #{tmp_source_file}"
+          run_command_in_agent(agent: agent, command: subcommand)
+
+          puts "Done!"
+        elsif destination.start_with?('container')
+          #SCP TO container
+          destination = destination.split(':').last
+          tmp_destination_file = '~/tmp_kc.tmp'
+          tmp_destination = generate_agent_scp_string(tmp_destination_file, agent)
+          scp_with_agent(source: source, agent: agent, destination: tmp_destination)
+          container_id = get_container_id_command(container.name)
+          subcommand = "#{'sudo ' if sudo}docker cp #{tmp_destination_file} \\`#{container_id}\\`:#{destination} && rm #{tmp_destination_file}"
+          run_command_in_agent(agent: agent, command: subcommand)
+          puts "Done!"
+        end
+      end
+    end
+
+    def generate_agent_scp_string(input, agent)
+      split_input = input.split(':')
+      location    = split_input.last
+      target_ip = bastion ? agent.private_ip : agent.public_ip
+      return "#{ssh_username}@#{target_ip}:#{location}"
+    end
+
+    def scp_with_agent(source:, destination:, agent: nil)
+      command = generate_scp_connection_string(agent: agent)
+      command += " #{source}"
+      command += " #{destination}"
+      system(command)
+      puts "Done!"
+    end
+
+    def generate_scp_connection_string(agent:)
+      ip = bastion ? agent.private_ip : agent.public_ip
+      command = "scp"
+      command += " -i #{rsa_key_location}" if rsa_key_location
+      command += " -o ProxyCommand='ssh -qxT #{bastion} nc #{ip} 22'" if bastion
+      command
+    end
+
+    def scp_to_container(source:, destination:)
+      container = select_container
+      agent     = container.task.agent
+      tmp_destination_file = '~/tmp_kc.tmp'
+      scp_to_agent(source: source, agent: agent, destination: tmp_destination_file)
+      container_id = get_container_id_command(container.name)
+      subcommand = "#{'sudo ' if sudo}docker cp #{tmp_destination_file} \\`#{container_id}\\`:#{destination} && rm #{tmp_destination_file}"
+      run_command_in_agent(agent: agent, command: subcommand)
+      puts "Done!"
+    end
+  end
+end

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '1.4.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
Turns out we needed to get a file from a container the other day.  This allows knuckle cluster to do that (previously it was only capable of putting files into containers/agents).

This changes the SCP syntax to be more 'scp-like' with the keyword `agent` or `container` in place of the actual remote.  Because of this, the version has been bumped to `2.0.0`

I've moved all of the SCP related code into it's own module just to keep it all grouped together.  A refactor is on the cards which will tidy a lot of the monolithic `knuckle_cluster.rb` up.