### PR TITLE
allow ssh config to be defined within KC config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ default_platform: &default_platform
   ssh_username: ubuntu
   sudo: true
   aws_vault_profile: platform_super_user
+
+default_platform: &default_platform
+  region: us-east-1
+  bastion:
+    username: ubuntu
+    host: bastion.endpoint.example.com
+    rsa_key_location: ~/.ssh/bastion_rsa_key
+  rsa_key_location: ~/.ssh/platform_rsa_key
+  ssh_username: ubuntu
+  sudo: true
+  aws_vault_profile: platform_super_user
 ```
 
 See [Options for Knuckle Cluster](#options-for-knuckle-cluster) below for a list of what each option does.
@@ -191,7 +202,7 @@ cluster_name | The name of the cluster (not the ARN). eg 'my-super-cluster'. One
 spot_request_id | The spot request ID you are connecting to. eg 'sfr-abcdef'. One of `cluster_name`,`spot_request_id` or `asg_name` is required.
 asg_name | The auto-scaling group name you are connecting to. eg 'very-scaly-group'. One of `cluster_name`,`spot_request_id` or `asg_name` is required.
 region | The AWS region you would like to use. Defaults to `us-east-1`
-bastion | if you have a bastion to proxy to your ecs cluster via ssh, put the name of it here as defined in your `~/.ssh/config` file.
+bastion | if you have a bastion to proxy to your ecs cluster via ssh, put the name of it here as defined in your `~/.ssh/config` file.  Alternatively, this can be a collection of keys for `username`, `host`, and `rsa_key_location`
 rsa_key_location | The RSA key needed to connect to an ecs agent eg `~/.ssh/id_rsa`.
 ssh_username | The username to conncet. Will default to `ec2-user`
 sudo | true or false - will sudo the `docker` command on the target machine. Usually not needed unless the user is not a part of the `docker` group.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ default_platform: &default_platform
   sudo: true
   aws_vault_profile: platform_super_user
 
-default_platform: &default_platform
+other_platform: &other_platform
   region: us-east-1
   bastion:
     username: ubuntu

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -189,7 +189,11 @@ module KnuckleCluster
       ip = bastion ? agent.private_ip : agent.public_ip
       command = "ssh #{ip} -l#{ssh_username}"
       command += " -i #{rsa_key_location}" if rsa_key_location
-      command += " -o ProxyCommand='ssh -qxT #{bastion} nc #{ip} 22'" if bastion
+      if bastion.is_a? String
+        command += " -o ProxyCommand='ssh -qxT #{bastion} nc #{ip} 22'"
+      elsif bastion.is_a? Hash
+        command += " -o Proxycommand='ssh -qxt #{bastion[:host]} -l#{bastion[:username]} -i #{bastion[:rsa_key_location]} nc #{ip} 22'"
+      end
       command += " -L #{port_forward}" if port_forward
       command += " -t \"#{subcommand}\"" if subcommand
       command

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
Previously, if using a bastion to connect to a thing, the bastion config needed to be set up inside the users `~/.ssh/config` file.  Now we can put the bastion `host`, `username` and `rsa_key_location` directly into the knuckle cluster config