### PR TITLE
Add handy dandy list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ See [Options for Knuckle Cluster](#options-for-knuckle-cluster) below for a list
 Command line options:
 
 ```
+knuckle_cluster list - list all available clusters
 knuckle_cluster CLUSTER_PROFILE agents - list all agents and select one to start a shell
 knuckle_cluster CLUSTER_PROFILE containers - list all containers and select one to start a shell
 knuckle_cluster CLUSTER_PROFILE logs CONTAINER_NAME - tail the logs for a container

--- a/bin/knuckle_cluster
+++ b/bin/knuckle_cluster
@@ -2,10 +2,16 @@
 require "knuckle_cluster"
 require "yaml"
 
+if ARGV[0] == 'list'
+  KnuckleCluster::Configuration.list
+  exit
+end
+
 profile = ARGV[0]
 
 if ARGV.count < 2
   puts <<~USAGE
+    knuckle_cluster list - list all available clusters
     knuckle_cluster CLUSTER_PROFILE agents - list all agents and select one to start a shell
     knuckle_cluster CLUSTER_PROFILE containers - list all containers and select one to start a shell
     knuckle_cluster CLUSTER_PROFILE logs CONTAINER_NAME - tail the logs for a container

--- a/lib/knuckle_cluster/configuration.rb
+++ b/lib/knuckle_cluster/configuration.rb
@@ -3,10 +3,8 @@ class KnuckleCluster::Configuration
   DEFAULT_PROFILE_FILE = File.join(ENV['HOME'],'.ssh/knuckle_cluster').freeze
 
   def self.load_parameters(profile:, profile_file: nil)
-    profile_file ||= DEFAULT_PROFILE_FILE
-    raise "File #{profile_file} not found" unless File.exists?(profile_file)
 
-    data = YAML.load_file(profile_file)
+    data = load_data(profile_file)
 
     unless data.keys.include?(profile)
       raise "Config file does not include profile for #{profile}"
@@ -31,6 +29,29 @@ class KnuckleCluster::Configuration
     output.delete('profile')
 
     keys_to_symbols(output)
+  end
+
+  def self.load_data(profile_file = nil)
+    @data ||= (
+      profile_file ||= DEFAULT_PROFILE_FILE
+      raise "File #{profile_file} not found" unless File.exists?(profile_file)
+      YAML.load_file(profile_file)
+    )
+  end
+
+  def self.list
+    data = []
+
+    KnuckleCluster::Configuration.load_data.each do |k,v|
+      tmp = {'name': k}
+      tmp['tunnels'] = v['tunnels'] ? v['tunnels'].keys.join(', ') : ''
+      tmp['shortcuts'] = v['shortcuts'] ? v['shortcuts'].keys.join(', ') : ''
+
+      data << tmp
+    end
+    puts "\nVersion #{KnuckleCluster::VERSION}"
+    puts "\nAvailable connections"
+    tp data.sort{|x,y| x[:name] <=> y[:name]}
   end
 
   private

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
Have you ever forgotten what you called a particular cluster profile?  I know I have!

You can now do `knuckle_cluster list` to view all of the configured clusters, their tunnels and shortcuts:

```
$ knuckle_cluster list
Version 2.2.0

Available connections
NAME                  | TUNNELS             | SHORTCUTS
----------------------|---------------------|--------------------------
cluster_one           | postgres            |
another_cluster       |                     | dbconsole
yet_another_cluster   |                     |
```