### PR TITLE
Add ability to hide tasks and/or containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ platform:
       local_port: 54321
       remote_host: postgres-db.yourcompany.com
       remote_port: 5432
+  hide:
+    container: some_container_regex_i_dont_care_about
+    task: some_task_regex_i_dont_care_about
 ```
 
 You can also use inheritance to simplify the inclusion of multiple similar targets:
@@ -209,6 +212,7 @@ ssh_username | The username to conncet. Will default to `ec2-user`
 sudo | true or false - will sudo the `docker` command on the target machine. Usually not needed unless the user is not a part of the `docker` group.
 aws_vault_profile | If you use the `aws-vault` tool to manage your AWS credentials, you can specify a profile here that will be automatically used to connect to this cluster.
 profile | Another profile to inherit settings from. Settings from lower profiles can be overridden in higher ones.
+hide | allows you to specify a regex for either `task` or `container` to omit these from being shown
 
 ## Spot Fleets
 If you wish to see what instances are running within a spot fleet, KnuckleCluster can do that too!.  In your config, use `spot_request_id` instead of `cluster_name`.  Note that the `containers` command will not work when invoking (use `agents` instead).

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -30,7 +30,8 @@ module KnuckleCluster
         sudo: false,
         aws_vault_profile: nil,
         shortcuts: {},
-        tunnels: {})
+        tunnels: {},
+        hide: {})
       @cluster_name      = cluster_name
       @spot_request_id   = spot_request_id
       @asg_name          = asg_name
@@ -42,6 +43,7 @@ module KnuckleCluster
       @aws_vault_profile = aws_vault_profile
       @shortcuts         = shortcuts
       @tunnels           = tunnels
+      @hide              = hide
 
       if @cluster_name.nil? && @spot_request_id.nil? && @asg_name.nil?
         raise "Must specify either cluster_name, spot_request_id or asg name"
@@ -205,6 +207,7 @@ module KnuckleCluster
           EcsAgentRegistry.new(
             aws_client_config: aws_client_config,
             cluster_name:      cluster_name,
+            hide:              @hide,
           )
         elsif @spot_request_id
           SpotRequestInstanceRegistry.new(

--- a/lib/knuckle_cluster/ecs_agent_registry.rb
+++ b/lib/knuckle_cluster/ecs_agent_registry.rb
@@ -7,9 +7,10 @@ module KnuckleCluster
   class EcsAgentRegistry
     extend Forwardable
 
-    def initialize(aws_client_config:, cluster_name:)
+    def initialize(aws_client_config:, cluster_name:, hide: {})
       @aws_client_config = aws_client_config
-      @cluster_name = cluster_name
+      @cluster_name      = cluster_name
+      @hide              = hide
     end
 
     def agents
@@ -72,6 +73,7 @@ module KnuckleCluster
         ecs_client:     ecs_client,
         cluster_name:   cluster_name,
         agent_registry: self,
+        hide:           @hide,
       )
     end
 

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
When listing containers or agents, we might want to hide some containers (eg some sort of agent that runs on each agent for example).   We can now specify a regex to omit these from the search results eg:

```
  hide:
    container: some_container_regex_i_dont_care_about
    task: some_task_regex_i_dont_care_about
```