### PR TITLE
Configure Github Action to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,16 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        ruby_version: [ '2.6', '2.7' ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
+    - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby_version }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating_system }}
     strategy:
       matrix:
-        ruby_version: [ '2.6', '2.7' ]
+        operating_system: [ ubuntu-latest, macos-latest ]
+        ruby_version: [ 2.6, 2.7 ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby_version }}

--- a/knuckle_cluster.gemspec
+++ b/knuckle_cluster.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~> 3.0"
   spec.add_development_dependency "pry",     "~> 0.11"


### PR DESCRIPTION
## Context

There is no CI service configured for this project.

## Change

* Remove the development dependency on bundler
* Configure a Github Action running the tests

## Considerations

### Dependency on Bundler

Bundler is a gem built in modern versions of Ruby. I don't think it is necessary to list it as a dependency.

### Github Actions as CI

Github Actions are configured in `.github/workflows/*.yml`. It can be used to run scripts like RSpec tests.

There are free quotas for public repos.
https://help.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions

I decide to give it a try instead of Travis CI because it was suggested and I don't have permissions to activate this project in Travis CI 😂 

Currently, it is configured to test with Ruby 2.6, 2.7 on Ubuntu and MacOS. Please see the results for this PR in the "Checks" tabs.