### PR TITLE
Fix deprecation warnings in Ruby 2.7

### DIFF
--- a/bin/knuckle_cluster
+++ b/bin/knuckle_cluster
@@ -31,7 +31,7 @@ rescue => e
 end
 
 kc = KnuckleCluster.new(
-  config
+  **config
 )
 
 if ARGV[1] == 'agents'

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -82,7 +82,7 @@ module KnuckleCluster
     def open_tunnel(name:)
       if tunnel = tunnels[name.to_sym]
         agent = select_agent(auto: true)
-        open_tunnel_via_agent(tunnel.merge(agent: agent))
+        open_tunnel_via_agent(**tunnel.merge(agent: agent))
       else
         puts "ERROR: A tunnel configuration was not found for '#{name}'"
       end


### PR DESCRIPTION
## Context

Ruby 2.7's deprecation warnings about keyword parameters are triggered in the `bin/knuckle_cluster` executable.

e.g.

```
$ bin/knuckle_cluster CLUSTER_PROFILE agents
.../lib/ruby/gems/2.7.0/gems/knuckle_cluster-2.3.2/bin/knuckle_cluster:33: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
.../lib/ruby/gems/2.7.0/gems/knuckle_cluster-2.3.2/lib/knuckle_cluster.rb:22: warning: The called method `new' is defined here

Listing Agents
INDEX | INSTANCE_ID         | TASK                                                    | CONTAINER
------|---------------------|---------------------------------------------------------|-------------------------------------------------
1     | ...                 | .......                                                 | .......
```

## Change

Fix the deprecation warnings.

## Considerations

After this is merged, I'll release a new version in another PR.