### PR TITLE
Bump version to 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0] - 2018-03-27
-Refactor SCP implementation to use new syntax
-Allow SCP copy files FROM agents or containers
+
+### Changed
+
+* Refactor SCP implementation to use new syntax
+* Allow SCP copy files FROM agents or containers
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.3] - 2020-05-11
+
+### Fixed
+
+* Fix deprecation warnings in Ruby 2.7 ([#28](https://github.com/envato/knuckle_cluster/pull/28))
+
 ## [2.0.0] - 2018-03-27
 
 ### Changed

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '2.3.2'
+  VERSION = '2.3.3'
 end


### PR DESCRIPTION
## Context

We need to release a new version to publish changes in https://github.com/envato/knuckle_cluster/pull/28.

## Change

Bump version to 2.3.3

## Considerations

I will tag and release the new version after this PR is merged.