### PR TITLE
POC for making knuckle cluster more human

### DIFF
--- a/bin/knuckle_cluster
+++ b/bin/knuckle_cluster
@@ -7,9 +7,42 @@ if ARGV[0] == 'list'
   exit
 end
 
-profile = ARGV[0]
+require 'pastel'
+pastel = Pastel.new
 
-if ARGV.count < 2
+profile = ARGV[0]
+if profile.nil? && STDIN.tty?
+  require 'tty-prompt'
+  prompt = TTY::Prompt.new
+  profile = prompt.select("Which profile should we use?", KnuckleCluster::Configuration.load_data.keys.sort)
+end
+subcommand = ARGV[1]
+if !profile.nil? && subcommand.nil? && STDIN.tty?
+  require 'tty-prompt'
+  prompt = TTY::Prompt.new
+  tunnels = KnuckleCluster::Configuration.load_data[profile]['tunnels']
+  shortcuts = KnuckleCluster::Configuration.load_data[profile]['shortcuts']
+  choices = {
+    'Connect to a CONTAINER': 'containers',
+    'Connect to an AGENT': 'agents',
+    'Tail the logs on a CONTAINER': 'logs',
+    'Run a command on a CONTAINER': 'run',
+    'Copy a file to or from a CONTAINER': 'scp',
+  }
+  if !tunnels.nil?
+    tunnels.each do |k, v|
+      choices["#{pastel.yellow("tunnel")} #{k}"] = ['tunnel', k]
+    end
+  end
+  if !shortcuts.nil?
+    shortcuts.each do |k, v|
+      choices["#{pastel.yellow("shortcut")} #{k}"] = ['shortcut', k]
+    end
+  end
+  subcommand = prompt.select("What would you like to do on #{pastel.green(profile)} today?", choices)
+end
+
+if !STDIN.tty? && (profile.nil? || subcommand.nil?)
   puts <<~USAGE
     knuckle_cluster list - list all available clusters
     knuckle_cluster CLUSTER_PROFILE agents - list all agents and select one to start a shell
@@ -34,13 +67,13 @@ kc = KnuckleCluster.new(
   **config
 )
 
-if ARGV[1] == 'agents'
+if subcommand == 'agents'
   kc.connect_to_agents
-elsif ARGV[1] == 'containers'
+elsif subcommand == 'containers'
   kc.connect_to_containers
-elsif ARGV[1] == 'logs'
+elsif subcommand == 'logs'
   kc.container_logs(name: ARGV[2])
-elsif ARGV[1] == 'tunnel'
+elsif subcommand == 'tunnel'
   kc.open_tunnel(name: ARGV[2])
 elsif ARGV[1] == 'scp'
   kc.initiate_scp(source: ARGV[2], destination: ARGV[3])

--- a/knuckle_cluster.gemspec
+++ b/knuckle_cluster.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-ec2',         '~> 1'
   spec.add_dependency 'aws-sdk-ecs',         '~> 1'
   spec.add_dependency 'aws-sdk-autoscaling', '~> 1'
+  spec.add_dependency 'tty-prompt'
+  spec.add_dependency 'tty-color'
+  spec.add_dependency 'pastel'
 
   spec.add_dependency 'table_print', '~> 1.5'
 


### PR DESCRIPTION
Quick spike to see how hard it would be to get knuckle cluster to be human friendly, as per https://clig.dev/#human-first-design. As per the notes there:

* Don't change the current interface, so any scripting still works
* If we have a terminal, guide the user to the right choice rather than just failing
* Use colours to make the interface more human friendly

This is terrible code, but it's a spike. If we like this idea we can
clean it up and make it better. Also not all the commands are implemented (e.g. scp requires file selection, run command needs a command to be entered), but it's the best I could do less than an hour

https://user-images.githubusercontent.com/42128830/110900005-29fffb00-8356-11eb-9d1d-1a5b44c5a568.mp4

Found there is the [TTY Toolkit](https://ttytoolkit.org/) for ruby, so used some gems from there for the dropdowns. Means that colouring honours terminal settings which is nice, but we still have to support NO_COLOR manually