### PR TITLE
Fix the error caused by the removal of `File.exists?` in Ruby 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## [2.3.4] - 2023-03-06
+
+### Fixed
+
+* Fix the error caused by the removal of `File.exists?` in Ruby 3.2 ([#31](https://github.com/envato/knuckle_cluster/pull/31))
+
 ## [2.3.3] - 2020-05-11
 
 ### Fixed
@@ -18,3 +26,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Refactor SCP implementation to use new syntax
 * Allow SCP copy files FROM agents or containers
 
+[unreleased]: https://github.com/envato/knuckle_cluster/compare/v2.3.4...HEAD
+[2.3.4]: https://github.com/envato/knuckle_cluster/compare/v2.3.2...v2.3.4
+[2.3.3]: https://github.com/envato/knuckle_cluster/compare/v2.3.2...v2.3.3

--- a/lib/knuckle_cluster/configuration.rb
+++ b/lib/knuckle_cluster/configuration.rb
@@ -34,7 +34,7 @@ class KnuckleCluster::Configuration
   def self.load_data(profile_file = nil)
     @data ||= (
       profile_file ||= DEFAULT_PROFILE_FILE
-      raise "File #{profile_file} not found" unless File.exists?(profile_file)
+      raise "File #{profile_file} not found" unless File.exist?(profile_file)
       YAML.load_file(profile_file)
     )
   end

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '2.3.3'
+  VERSION = '2.3.4'
 end


### PR DESCRIPTION
## Context

Running Knuckle Cluster commands with Ruby 3.2 ends up with the following error message.

```
ERROR: There was a problem loading your configuration: undefined method `exists?' for File:Class
```

## Change

Replace `File.exists?` with `File.exist?`

## Considerations

### The issue

`File.exists?` was an alias to `File.exist?`. The alias was removed in Ruby 3.2.

### Release

Once this PR is approved, I will release a new version of the gem.

### Testing

I manually tested this change in my development environment (Ruby 3.2.1 on macOS). It fixes the issue for me.

This project is not tested against Ruby 3. Setting up tests for Ruby 3 takes a bit more than I imagined. I think that should be handled separately to this PR.