### PR TITLE
Move development dependencies from gemspec to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in knuckle_cluster.gemspec
 gemspec
+
+group :development do
+  gem 'pry'
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
+end

--- a/knuckle_cluster.gemspec
+++ b/knuckle_cluster.gemspec
@@ -19,10 +19,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake",    "~> 10.0"
-  spec.add_development_dependency "rspec",   "~> 3.0"
-  spec.add_development_dependency "pry",     "~> 0.11"
-
   spec.add_dependency 'aws-sdk-core',        '~> 3'
   spec.add_dependency 'aws-sdk-ec2',         '~> 1'
   spec.add_dependency 'aws-sdk-ecs',         '~> 1'


### PR DESCRIPTION
Resolve [Gemspec/DevelopmentDependencies](https://www.rubydoc.info/gems/rubocop/1.56.3/RuboCop/Cop/Gemspec/DevelopmentDependencies).