### PR TITLE
Be explicit that agent/container index is being requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ task-three        | i-456def456def456de | 4     | t3-container-one
                   |                     | 5     | t3-container-two
                   |                     | 6     | t3-container-three
 
-Connect to which container?
+Connect to which container? (INDEX)
 ```
 
 Same with connecting directly to agents
@@ -179,7 +179,7 @@ INDEX | INSTANCE_ID         | TASK       | CONTAINER
       |                     |            | t3-container-two
       |                     |            | t3-container-three
 
-Connect to which agent?
+Connect to which agent? (INDEX)
 ```
 
 Both `connect_to_containers` and `connect_to_agents` can have the following optional arguments:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ task-three        | i-456def456def456de | 4     | t3-container-one
                   |                     | 5     | t3-container-two
                   |                     | 6     | t3-container-three
 
-Connect to which container? (INDEX)
+Enter the INDEX number and press ENTER to connect:
 ```
 
 Same with connecting directly to agents
@@ -179,7 +179,7 @@ INDEX | INSTANCE_ID         | TASK       | CONTAINER
       |                     |            | t3-container-two
       |                     |            | t3-container-three
 
-Connect to which agent? (INDEX)
+Enter the INDEX number and press ENTER to connect:
 ```
 
 Both `connect_to_containers` and `connect_to_agents` can have the following optional arguments:

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -101,7 +101,7 @@ module KnuckleCluster
 
       output_agents
 
-      puts "\nConnect to which agent? (INDEX)"
+      puts "\nEnter the INDEX number and press ENTER to connect:"
       agents[STDIN.gets.strip.to_i - 1]
     end
 
@@ -116,7 +116,7 @@ module KnuckleCluster
          { index: { display_method: 'containers.index' } },
          { container: { display_method: 'containers.name', width: 999 } }
 
-      puts "\nConnect to which container? (INDEX)"
+      puts "\nEnter the INDEX number and press ENTER to connect:"
       containers[STDIN.gets.strip.to_i - 1]
     end
 

--- a/lib/knuckle_cluster.rb
+++ b/lib/knuckle_cluster.rb
@@ -101,7 +101,7 @@ module KnuckleCluster
 
       output_agents
 
-      puts "\nConnect to which agent?"
+      puts "\nConnect to which agent? (INDEX)"
       agents[STDIN.gets.strip.to_i - 1]
     end
 
@@ -116,7 +116,7 @@ module KnuckleCluster
          { index: { display_method: 'containers.index' } },
          { container: { display_method: 'containers.name', width: 999 } }
 
-      puts "\nConnect to which container?"
+      puts "\nConnect to which container? (INDEX)"
       containers[STDIN.gets.strip.to_i - 1]
     end
 


### PR DESCRIPTION
>Connect to which container?

It was not immediately clear to me that the index rather than name is being requested on the command line.

>STDIN.gets.strip.to_i

This code happily accepts a container name although the to_i turns it into a zero.

This PR modifies the command line prompt to explicitly state that an index should be entered.