### PR TITLE
Bump version to 2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.3.5] - 2025-03-09
+
+* Be explicit that an index number is expected in the lists for agents and containers ([#36](https://github.com/envato/knuckle_cluster/pull/36))
+
 ## [2.3.4] - 2023-03-06
 
 ### Fixed
@@ -26,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Refactor SCP implementation to use new syntax
 * Allow SCP copy files FROM agents or containers
 
-[unreleased]: https://github.com/envato/knuckle_cluster/compare/v2.3.4...HEAD
-[2.3.4]: https://github.com/envato/knuckle_cluster/compare/v2.3.2...v2.3.4
+[unreleased]: https://github.com/envato/knuckle_cluster/compare/v2.3.5...HEAD
+[2.3.5]: https://github.com/envato/knuckle_cluster/compare/v2.3.4...v2.3.5
+[2.3.4]: https://github.com/envato/knuckle_cluster/compare/v2.3.3...v2.3.4
 [2.3.3]: https://github.com/envato/knuckle_cluster/compare/v2.3.2...v2.3.3

--- a/lib/knuckle_cluster/version.rb
+++ b/lib/knuckle_cluster/version.rb
@@ -1,3 +1,3 @@
 module KnuckleCluster
-  VERSION = '2.3.4'
+  VERSION = '2.3.5'
 end


### PR DESCRIPTION
## Context

The UX improvement in https://github.com/envato/knuckle_cluster/pull/36 has not been released yet.

## Change

Bump version to 2.3.5.

## Considerations

I will release a new version to RubyGems once this is merged.